### PR TITLE
Add start_assetid for partial inventory fetch. 

### DIFF
--- a/aiosteampy/mixins/public.py
+++ b/aiosteampy/mixins/public.py
@@ -28,7 +28,7 @@ from .http import SteamHTTPTransportMixin
 
 
 # steam limit rules
-INV_COUNT = 5000
+INV_COUNT = 2000
 LISTING_COUNT = 10
 
 INVENTORY_URL = STEAM_URL.COMMUNITY / "inventory"

--- a/aiosteampy/mixins/public.py
+++ b/aiosteampy/mixins/public.py
@@ -66,6 +66,7 @@ class SteamCommunityPublicMixin(SteamHTTPTransportMixin):
         *,
         last_assetid: int = None,
         count=INV_COUNT,
+        start_assetid: int = None,
         params: T_PARAMS = {},
         headers: T_HEADERS = {},
         _item_descriptions_map: T_SHARED_DESCRIPTIONS = None,
@@ -81,6 +82,7 @@ class SteamCommunityPublicMixin(SteamHTTPTransportMixin):
         :param app_context: `Steam` app+context
         :param last_assetid:
         :param count: page size
+        :param start_assetid: start_assetid for partial inv fetch
         :param params: extra params to pass to url
         :param headers: extra headers to send with request
         :return: list of `EconItem`, total count of items in inventory, last asset id of the list
@@ -93,6 +95,8 @@ class SteamCommunityPublicMixin(SteamHTTPTransportMixin):
         params = {"l": self.language, "count": count, **params}
         if last_assetid:
             params["last_assetid"] = last_assetid
+        if start_assetid:
+            params["start_assetid"] = start_assetid
         headers = {"Referer": str(inv_url), **headers}
 
         try:
@@ -215,6 +219,7 @@ class SteamCommunityPublicMixin(SteamHTTPTransportMixin):
         *,
         last_assetid: int = None,
         count=INV_COUNT,
+        start_assetid: int = None,
         params: T_PARAMS = {},
         headers: T_HEADERS = {},
         _item_descriptions_map: T_SHARED_DESCRIPTIONS = None,
@@ -228,6 +233,7 @@ class SteamCommunityPublicMixin(SteamHTTPTransportMixin):
         :param app_context: `Steam` app+context
         :param last_assetid:
         :param count: page size
+        :param start_assetid: start_assetid for partial inv fetch
         :param params: extra params to pass to url
         :param headers: extra headers to send with request
         :return: `AsyncIterator` that yields list of `EconItem`, total count of items in inventory, last asset id of the list
@@ -248,6 +254,7 @@ class SteamCommunityPublicMixin(SteamHTTPTransportMixin):
                 app_context,
                 last_assetid=last_assetid,
                 count=count,
+                start_assetid=start_assetid,
                 params=params,
                 headers=headers,
                 _item_descriptions_map=_item_descriptions_map,


### PR DESCRIPTION


## Change Summary

Added parameter `start_assetid` for inventory fetching since max inventory size request now is less than max inventory size.
See https://github.com/DoctorMcKay/node-steamcommunity/blob/0d991c265549a1b2bf3e09d248321f36917599a0/components/users.js#L585 

## Related issues
get_user_inventory_item() will still have an issue with too large default count value (need <=2000)

## Checklist

* [x] My pull request adheres to the code style of this project
* [x] The pull request title is a good summary of the changes
* [x] Documentation reflects the changes where applicable

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
