### PR TITLE
Fix #84 : _parse_item_order_histogram_price() return wrong price

### DIFF
--- a/aiosteampy/mixins/public.py
+++ b/aiosteampy/mixins/public.py
@@ -482,7 +482,7 @@ class SteamCommunityPublicMixin(SteamHTTPTransportMixin):
         if text is None:
             return None
 
-        raw_price = ITEM_ORDER_HIST_PRICE_RE.search(text).group(1)
+        raw_price = ITEM_ORDER_HIST_PRICE_RE.search(text.replace(" ","")).group(1)
 
         if "." not in raw_price and "," not in raw_price:
             price = int(raw_price) * 100  # add cents


### PR DESCRIPTION
<!-- Thank you for your contribution! ✊ -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->
Changed function _parse_item_order_histogram_price() to return correct price, fixed by replace all spaces in price.

## Related issues

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->
Bug #84 
## Checklist

* [x] My pull request adheres to the code style of this project
* [x] The pull request title is a good summary of the changes
* [x] Documentation reflects the changes where applicable

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
