### PR TITLE
Add a new ConfirmationType - PURCHASE

### DIFF
--- a/aiosteampy/constants.py
+++ b/aiosteampy/constants.py
@@ -221,6 +221,7 @@ class ConfirmationType(Enum):
     TRADE = 2
     LISTING = 3
     API_KEY = 4  # TODO find api key value
+    PURCHASE = 12
 
     @classmethod
     def get(cls, v: int) -> "ConfirmationType":


### PR DESCRIPTION
Valve recently added confirmation on purchase. Adding this new enum item is sufficient for SteamClient.allow_confirmation to work.

<!-- Thank you for your contribution! ✊ -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issues

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] My pull request adheres to the code style of this project
* [ ] The pull request title is a good summary of the changes
* [ ] Documentation reflects the changes where applicable

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
