### PR TITLE
Update constants.py for TradeOfferStatus with new status 12 for steam reverse trade update

### DIFF
--- a/aiosteampy/constants.py
+++ b/aiosteampy/constants.py
@@ -213,6 +213,7 @@ class TradeOfferStatus(Enum):
     CONFIRMATION_NEED = 9
     CANCELED_BY_SECONDARY_FACTOR = 10
     STATE_IN_ESCROW = 11
+    TRADE_REVERSED = 12
 
 
 # https://github.com/DoctorMcKay/node-steamcommunity/blob/master/resources/EConfirmationType.js


### PR DESCRIPTION
Added trade_reversed status in TradeOfferStatus, this fixes all the "12 is not a valid TradeOfferStatus" errors, including the one where if you have a reversed trade, fetching get_trade_history() will result in this error

<!-- Thank you for your contribution! ✊ -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issues

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ x] My pull request adheres to the code style of this project
* [ x] The pull request title is a good summary of the changes
* [ x] Documentation reflects the changes where applicable

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
