### PR TITLE
fix(confirmations): use list of tuples for batch confirmation form data

### DIFF
--- a/aiosteampy/guard/confirmations.py
+++ b/aiosteampy/guard/confirmations.py
@@ -319,12 +319,15 @@ class SteamConfirmations:
         """
 
         tag = "allow" if accept else "cancel"
-        data = self._create_confirmation_params(tag)
-        data["op"] = tag
-        data["cid[]"] = [conf.id for conf in confs]
-        data["ck[]"] = [conf.nonce for conf in confs]
+        base = self._create_confirmation_params(tag)
+        base["op"] = tag
+        # wreq form requires Sequence[Tuple] for repeated keys; dict with list values is not accepted
+        form_data: list = list(base.items())
+        for conf in confs:
+            form_data.append(("cid[]", conf.id))
+            form_data.append(("ck[]", conf.nonce))
 
-        r = await self._session.transport.request("POST", SEND_MULTI_URL, data=data, response_mode="json")
+        r = await self._session.transport.request("POST", SEND_MULTI_URL, data=form_data, response_mode="json")
         rj: dict = r.content
 
         EResultError.check_data(rj)


### PR DESCRIPTION
<!-- Thank you for your contribution! ✊ -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
  `send_multiple` built the POST body as a dict with list values for `cid[]` and `ck[]`, which is not supported by the wreq transport (requires `Mapping[str, scalar]` or `Sequence[Tuple[str, scalar]]`).
  This also caused silent data corruption with aiohttp, which would stringify the list as `"[1, 2, 3]"` instead of emitting repeated form fields.

  Fix: convert form data to a flat list of `(key, value)` tuples - the standard way to encode repeated form fields, compatible with both transports.

<!-- Please give a short summary of the changes. -->

## Related issues

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] My pull request adheres to the code style of this project
* [x] The pull request title is a good summary of the changes
* [x] Documentation reflects the changes where applicable

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
