### PR TITLE
Fix KeyError when market_bucket_group fields are absent in item description

### DIFF
--- a/aiosteampy/client/econ.py
+++ b/aiosteampy/client/econ.py
@@ -115,7 +115,7 @@ class ItemDescription(BaseEntityWithIdentCode):
     name: str
     market_name: str
     market_hash_name: str
-    market_bucket_group: MarketBucketGroup
+    market_bucket_group: MarketBucketGroup | None = None
 
     type: str | None = None
 
@@ -312,9 +312,13 @@ class EconMixin:
             name=data["name"],
             market_name=data["market_name"],
             market_hash_name=data["market_hash_name"],
-            market_bucket_group=MarketBucketGroup(
-                data["market_bucket_group_id"],
-                data["market_bucket_group_name"],
+            market_bucket_group=(
+                MarketBucketGroup(
+                    data["market_bucket_group_id"],
+                    data["market_bucket_group_name"],
+                )
+                if "market_bucket_group_id" in data
+                else None
             ),
             name_color=data.get("name_color") or None,  # ignore " "
             background_color=data.get("name_color") or None,


### PR DESCRIPTION
### Problem

`EconMixin._create_item_descr` reads `market_bucket_group_id` and
`market_bucket_group_name` via hard subscript (`data["..."]`), while every
other optional description field around it uses `data.get(...)`.

Steam's `/market/mylistings` (`norender=1`) endpoint omits these fields for
some items, and the two keys do **not** necessarily arrive together. Any item
missing one of them raises `KeyError` and aborts the whole
`Market.get_user_listings` call (also breaks
`get_listings_awaiting_confirmation`-style flows that depend on it).

### Traceback (observed on v1.0.0b2)

```
File ".../aiosteampy/client/components/market/market.py", line 209, in get_user_listings
    self._parse_descriptions_from_my_listings_or_market_history(rj, _item_descriptions_map)
File ".../aiosteampy/client/components/market/market.py", line 86, in _parse_descriptions_from_my_listings_or_market_history
    item_descriptions_map[key] = cls._create_item_descr(mixed_data)
File ".../aiosteampy/client/econ.py", line 316, in _create_item_descr
    data["market_bucket_group_id"],
KeyError: 'market_bucket_group_id'
```

### Fix

- Read each key independently via `.get()` so neither hard subscript can raise,
  regardless of which subset of the two keys Steam returns.
- Build `MarketBucketGroup` only when at least one of the keys is present,
  otherwise set the field to `None`.
- Make `MarketBucketGroup.id` / `.name` and `ItemDescription.market_bucket_group`
  optional accordingly (mirrors the existing `market_fee_app: App | None` idiom).

### Behaviour

| incoming keys      | result                                   |
|--------------------|------------------------------------------|
| both               | `MarketBucketGroup(id=..., name=...)`    |
| only id            | `MarketBucketGroup(id=..., name=None)`   |
| only name          | `MarketBucketGroup(id=None, name=...)`   |
| neither            | `None`                                   |

No `KeyError` in any case.