### PR TITLE
fix(market): avoid KeyError when buy order has no description

### DIFF
--- a/aiosteampy/client/components/market/market.py
+++ b/aiosteampy/client/components/market/market.py
@@ -153,22 +153,29 @@ class MarketComponent(MarketPublicComponent):
 
     @classmethod
     def _parse_buy_orders(cls, orders: list[dict], item_descriptions_map: ItemDescriptionsMap) -> list[BuyOrder]:
-        return [
-            BuyOrder(
-                id=int(o_data["buy_orderid"]),
-                price=int(o_data["price"]),
-                item_description=item_descriptions_map[
-                    create_ident_code(
-                        o_data["description"]["instanceid"],
-                        o_data["description"]["classid"],
-                        o_data["description"]["appid"],
-                    )
-                ],
-                quantity=int(o_data["quantity"]),
-                quantity_remaining=int(o_data["quantity_remaining"]),
+        buy_orders = []
+        for o_data in orders:
+            descr_data = o_data.get("description")
+            if not descr_data:  # ignore orders with invalid outdated descriptions
+                continue
+
+            buy_orders.append(
+                BuyOrder(
+                    id=int(o_data["buy_orderid"]),
+                    price=int(o_data["price"]),
+                    item_description=item_descriptions_map[
+                        create_ident_code(
+                            descr_data["instanceid"],
+                            descr_data["classid"],
+                            descr_data["appid"],
+                        )
+                    ],
+                    quantity=int(o_data["quantity"]),
+                    quantity_remaining=int(o_data["quantity_remaining"]),
+                )
             )
-            for o_data in orders
-        ]
+
+        return buy_orders
 
     async def get_user_listings(
         self,


### PR DESCRIPTION
Steam returns buy orders with invalid/outdated descriptions that omit the `description` key. `MarketComponent._parse_buy_orders` subscripts `o_data["description"]` directly, so a single such order raises `KeyError: 'description'` and aborts the whole `get_user_listings` call (hit via `get_listings_awaiting_confirmation`).

The sibling `_parse_descriptions_from_my_listings_or_market_history` already skips these orders (`data.get("description")` falsy → "ignore orders with invalid outdated descriptions"). This change mirrors that behaviour in `_parse_buy_orders`, so one broken buy order no longer fails the listings request.

**Note:** these orders are dropped silently, matching the existing sibling handling. If visibility into what Steam actually returns for such orders is desirable, a debug/warning log of the skipped raw order dict could be added here — left out for parity, happy to add if preferred.

```
Traceback (most recent call last):
  File ".../aiosteampy/client/components/market/market.py", line 215, in get_user_listings
    self._parse_buy_orders(rj["buy_orders"], _item_descriptions_map),
  File ".../aiosteampy/client/components/market/market.py", line 162, in _parse_buy_orders
    o_data["description"]["instanceid"],
KeyError: 'description'
```