### PR TITLE
Add AlreadyPurchased exception

### DIFF
--- a/aiosteampy/client/components/market/exceptions.py
+++ b/aiosteampy/client/components/market/exceptions.py
@@ -11,3 +11,6 @@ class InsufficientBalance(MarketError):
 
 class ListingRemoved(MarketError):
     """Listing has been removed."""
+
+class AlreadyPurchased(MarketError):
+    """You have already purchased this listing."""

--- a/aiosteampy/client/components/market/market.py
+++ b/aiosteampy/client/components/market/market.py
@@ -731,6 +731,8 @@ class MarketComponent(MarketPublicComponent):
                     error_data: dict = e.json()
                     if "somebody else has already purchased it" in error_data["message"]:
                         raise ListingRemoved from e
+                    elif "You've already purchased this item" in error_data["message"]:
+                        raise AlreadyPurchased from e
                     else:
                         raise InsufficientBalance from e
                 else:


### PR DESCRIPTION
## Change Summary

- Added a custom `AlreadyPurchased` exception class to represent cases where an item or game has already been bought.
- Updated the purchase handling logic to raise this exception, providing more specific details and clearer context when a purchase fails for this reason.

## Related issues

## Checklist

* [x] My pull request adheres to the code style of this project
* [x] The pull request title is a good summary of the changes
* [x] Documentation reflects the changes where applicable

## Additional Information

This improves error tracing and allows API users to distinctively catch `AlreadyPurchased` errors instead of generic failure exceptions.