### PR TITLE
Update separator for tradable after description

### DIFF
--- a/aiosteampy/client/econ.py
+++ b/aiosteampy/client/econ.py
@@ -174,7 +174,7 @@ class ItemDescription(BaseEntityWithIdentCode):
     def _set_restrictions_end_time(self):
         if self.market_tradable_restriction or self.market_marketable_restriction:
             # find tradable after description
-            sep = "Tradable/Marketable After "
+            sep = "Tradable After: "
             if (t_a_descr := next(filter(lambda d: sep in d.value, self.owner_descriptions), None)) is not None:
                 date_string = t_a_descr.value.split(sep)[1]
                 self.hold_until = datetime.strptime(date_string, TRADABLE_AFTER_DATE_FORMAT)


### PR DESCRIPTION
Looks like for TF2 we have:
descriptions = (ItemDescriptionEntry(value='\nTradable After: Tuesday, June 23, 2026 (7:00:00) GMT', type=None, name='attribute', color='d83636'),)

If they are different for CS2 we need moar branches

<!-- Thank you for your contribution! ✊ -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Suggestion to modify trade restriction description string

## Related issues


## Checklist

* [x] My pull request adheres to the code style of this project
* [x] The pull request title is a good summary of the changes
* [x] Documentation reflects the changes where applicable

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
