### PR TITLE
Fix StopIteration in ItemDescription._set_locked for locked items without a "[/date]" owner description

### DIFF
--- a/aiosteampy/client/econ.py
+++ b/aiosteampy/client/econ.py
@@ -188,7 +188,8 @@ class ItemDescription(BaseEntityWithIdentCode):
 
     def _set_locked(self):
         if locked_descr := next(
-            d for d in self.owner_descriptions if d.type == "bbcode" and d.value.endswith("[/date]")
+            (d for d in self.owner_descriptions if d.type == "bbcode" and d.value.endswith("[/date]")),
+            None,
         ):
             self.unlock_at = datetime.fromtimestamp(
                 int(LOCKED_DATE_RE.search(locked_descr.value).group(1)),


### PR DESCRIPTION
# Fix StopIteration in ItemDescription._set_locked for locked items without a "[/date]" owner description

## Problem

`ItemDescription._set_locked` looks up the bbcode "[/date]" owner description
with a bare `next(...)` that has **no default**:

```python
def _set_locked(self):
    if locked_descr := next(
        d for d in self.owner_descriptions if d.type == "bbcode" and d.value.endswith("[/date]")
    ):
        ...
```

`__post_init__` calls `_set_locked()` whenever the item is `sealed` or
trade/marketable-restricted and not marketable/tradable. Steam returns such
items that have **no** bbcode `"[/date]"` owner description, so the generator
is exhausted and `next()` raises `StopIteration`.

Because parsing runs inside the async market/inventory coroutines, PEP 479
converts that `StopIteration` into `RuntimeError: coroutine raised StopIteration`,
which aborts the entire `get_user_market_history` / inventory page — not just
the single offending item.

## Reproduction

A `sealed`/locked item description whose `owner_descriptions` contains no
`type == "bbcode"` entry ending in `"[/date]"` triggers it. Traceback
(library frames only):

```
Traceback (most recent call last):
  File "aiosteampy/client/components/market/market.py", line 941, in get_user_market_history
    self._parse_descriptions_from_my_listings_or_market_history(rj, _item_descriptions_map)
  File "aiosteampy/client/components/market/market.py", line 86, in _parse_descriptions_from_my_listings_or_market_history
    item_descriptions_map[key] = cls._create_item_descr(mixed_data)
  File "aiosteampy/client/econ.py", line 349, in _create_item_descr
    return ItemDescription(
        class_id=int(data["classid"]),
    ...<32 lines>...
        sealed_type=SealedType.get(data.get("sealed_type")),
    )
  File "<string>", line 32, in __init__
  File "aiosteampy/client/econ.py", line 184, in __post_init__
    self._set_locked()
  File "aiosteampy/client/econ.py", line 190, in _set_locked
    if locked_descr := next(
        d for d in self.owner_descriptions if d.type == "bbcode" and d.value.endswith("[/date]")
    ):
StopIteration

The above exception was the direct cause of the following exception:

RuntimeError: coroutine raised StopIteration
```

## Fix

Give `next()` a `None` default (and parenthesize the generator expression), so
a missing date description leaves `unlock_at` as `None` instead of raising.
This matches the sibling lookups in `_set_restrictions_end_time`, which already
use `next(filter(...), None)`.

## Notes

Affects 1.0.0b10. The normal path (a present `[date]<unix>[/date]` bbcode owner
description) is unchanged and still parses into `unlock_at`.
