### PR TITLE
fix(cs2): swap charm meta.name and meta.icon to match sticker parsing

### DIFF
--- a/aiosteampy/client/cs2.py
+++ b/aiosteampy/client/cs2.py
@@ -117,7 +117,7 @@ class DescriptionContext:
                     stickers = tuple(ItemAccessoryMeta(t, s) for s, t in CS2_APPLICABLE_DATA_RE.findall(d.value))
                 case DescriptionDescriptionName.Charm:
                     search = CS2_APPLICABLE_DATA_RE.search(d.value)
-                    charm = ItemAccessoryMeta(name=search.group(1), icon=search.group(2))
+                    charm = ItemAccessoryMeta(name=search.group(2), icon=search.group(1))
                 case DescriptionDescriptionName.Collection:
                     collection = d.value
                 case DescriptionDescriptionName.Exterior:  # safe to get from descriptions in any case


### PR DESCRIPTION
## Change Summary

DescriptionContext.from_description parsed sticker and charm <img> tags through the same regex, but passed the capture groups in opposite order:

- stickers: ItemAccessoryMeta(t, s)  # name=title, icon=src
- charm:    ItemAccessoryMeta(name=group(1), icon=group(2))
            # before: name=src, icon=title

Swap charm groups so ItemAccessoryMeta(name, icon) is consistent with stickers and with the NamedTuple contract.


## Checklist

* [x] My pull request adheres to the code style of this project
* [x] The pull request title is a good summary of the changes
* [x] Documentation reflects the changes where applicable

