### PR TITLE
fix(market): unwrap new data envelope of beta market responses

### DIFF
--- a/aiosteampy/client/components/market/public.py
+++ b/aiosteampy/client/components/market/public.py
@@ -70,6 +70,21 @@ SEARCH_ACTION_ROUTE_ID = "8cnlIgBs66uLKD68o1fzpLlHFSHv52c4l9_ohRpMLzk:"
 SEARCH_MARKET_ROUTE_ID = "hqTDeI5ivFCB0Wv5PoSzcv3T0xSiAA-lh744pmngd9M:"
 
 
+def unwrap_data_envelope(rj: dict) -> dict:
+    """
+    Unwrap an extra ``{"data": {...}}`` envelope that `Steam` started to add to some
+    modern(beta) market responses (observed on the `orderbook` endpoint since August 2026).
+    The envelope moves the whole payload, including the "success" field, one level deeper,
+    making ``EResultError.check_data`` fail with `0 - INVALID` on a valid response.
+    Responses without the envelope are returned unchanged.
+    """
+
+    if "success" not in rj and isinstance(rj.get("data"), dict) and "success" in rj["data"]:
+        return rj["data"]
+
+    return rj
+
+
 class MarketPublicComponent(EconMixin):
     """Component with public `Steam Market` methods. Available without authentication."""
 
@@ -1075,7 +1090,7 @@ class MarketPublicComponent(EconMixin):
             headers=headers,
             response_mode="json",
         )
-        rj: dict = r.content
+        rj: dict = unwrap_data_envelope(r.content)
 
         EResultError.check_data(rj)
 
@@ -1117,7 +1132,7 @@ class MarketPublicComponent(EconMixin):
             headers=headers,
             response_mode="json",
         )
-        rj: dict = r.content
+        rj: dict = unwrap_data_envelope(r.content)
 
         EResultError.check_data(rj)
 

--- a/tests/test_market_public.py
+++ b/tests/test_market_public.py
@@ -1,0 +1,23 @@
+from aiosteampy.client.components.market.public import unwrap_data_envelope
+
+
+class TestUnwrapDataEnvelope:
+    def test_unwraps_enveloped_success_response(self):
+        payload = {"success": True, "data": {"eCurrency": 1, "rgCompactBuyOrders": []}}
+
+        assert unwrap_data_envelope({"data": payload}) is payload
+
+    def test_unwraps_enveloped_error_response(self):
+        payload = {"success": 15, "message": "Access Denied"}
+
+        assert unwrap_data_envelope({"data": payload}) is payload
+
+    def test_keeps_flat_response_unchanged(self):
+        rj = {"success": 1, "data": {"eCurrency": 1, "rgCompactBuyOrders": []}}
+
+        assert unwrap_data_envelope(rj) is rj
+
+    def test_keeps_response_without_success_field_unchanged(self):
+        rj = {"data": ["not", "a", "dict"]}
+
+        assert unwrap_data_envelope(rj) is rj


### PR DESCRIPTION
## Problem

Since ~2026-08-13 Steam wraps the `/market/orderbook` (modern/beta market) JSON response into an extra `{"data": {...}}` envelope:

```json
// before
{"success": 1, "data": {"eCurrency": ..., "rgCompactBuyOrders": [...], ...}}

// now
{"data": {"success": true, "data": {"eCurrency": ..., "rgCompactBuyOrders": [...], ...}}}
```

`get_orderbook` calls `EResultError.check_data` on the top level, where `success` is no longer present, so **every** orderbook request fails with `EResultError: 0 - INVALID` even though the payload inside is complete and valid.

Easy to reproduce without authentication:

```bash
curl -sG 'https://steamcommunity.com/market/orderbook' \
  --data-urlencode 'q=Load' \
  --data-urlencode 'qp=[730, "AK-47 | Redline (Field-Tested)"]' \
  -H 'Referer: https://steamcommunity.com/market/search' \
  -H 'x-valve-request-type: queryAction'
```

## Fix

Added `unwrap_data_envelope` which peels the envelope off before `EResultError.check_data` and returns the response unchanged when the envelope is absent, so the change is backward compatible if Steam rolls the format back. Enveloped error responses (`success != 1` inside the envelope) are unwrapped too, so `check_data` still raises the proper `EResultError`.

Applied to both `queryAction` endpoints — `get_orderbook` (where the new format is confirmed live) and `get_search_app_facets` (same request family; a no-op while its response stays flat).

## Tests

- Added `tests/test_market_public.py` covering the enveloped success/error responses and the pass-through of the old flat format.
- Verified against a live `/market/orderbook` response: after unwrapping, `check_data` passes and the `OrderBook` payload parses correctly.
- `ruff check` introduces no new findings.
